### PR TITLE
Configure keys on a per bucket basis and make mounts persist after reboot

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,21 +1,19 @@
 Description
-----------------------
+-----------
 
-Instals fuse over amazon allowing to mount a bucket for access as a directory
+Installs s3fs allowing you to mount an AWS S3 bucket for access as a directory
 
-Required variables
-----------------------
+Role Variables
+--------------
 
-Please specify these in your playbook before using this role::
-
-
-    s3fs_aws_key
+Specify the mount point, the bucket to be mounted and the key to be used as
+follows:
 
     s3fs_mounts:
-        - { mount: <mount directory>, bucket: <bucket name> }
-        - { mount: /mnt/s3, bucket: mybackupbucket }
+        - { mount: <mount point>, bucket: <bucket name>, key: "<access key id:secret access key>" }
+        - { mount: /mnt/s3, bucket: mybackupbucket, key: "ALIAIORJQUJYV49V3RQ:13XqKwmeppogfeBnVXMr+lsdfdsLjNwk6JP+LFnyXf" }
     
 References
-----------------------
+----------
 
 - https://github.com/s3fs-fuse/s3fs-fuse/wiki/Installation-Notes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,7 +37,7 @@
       - make install
     when: s3_exists|failed
 
-  - name: create password file
+  - name: "create password file"
     sudo: yes
     file: path=/etc/passwd-s3fs state=touch mode=0400
 
@@ -46,12 +46,16 @@
     sudo: yes
     with_items: s3fs_mounts
 
-  - name: create mount point
+  - name: "create mount point"
     sudo: yes
     file: "path={{ item.mount }} state=directory"
     with_items: s3fs_mounts
 
-  - name: mount the bucket
+  - name: "mount the bucket"
     sudo: yes
     command: s3fs {{ item.bucket }} -o use_cache=/tmp -o allow_other {{ item.mount }}
+    with_items: s3fs_mounts
+
+  - name: "add the mount to /etc/fstab"
+    mount: name={{ item.mount }} src="s3fs#{{ item.bucket }}" fstype=fuse opts="_netdev,allow_other" state=present
     with_items: s3fs_mounts

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -49,11 +49,9 @@
   - name: create mount point
     sudo: yes
     file: "path={{ item.mount }} state=directory"
-    when: s3_exists|failed
     with_items: s3fs_mounts
 
   - name: mount the bucket
     sudo: yes
     command: s3fs {{ item.bucket }} -o use_cache=/tmp -o allow_other {{ item.mount }}
-    when: s3_exists|failed
     with_items: s3fs_mounts

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,12 +18,9 @@
       - autoconf
     when: s3_exists|failed
 
-  - name: "copy src & password"
-    copy: "src=../files/s3fs-{{ s3fs_version }}.zip dest=/tmp mode=0644"
-
-  - name: "copy src & password"
-    copy: "src={{ s3fs_aws_key }}  dest=/etc/passwd-s3fs mode=400"
+  - name: "copy src"
     sudo: yes
+    copy: "src=../files/s3fs-{{ s3fs_version }}.zip dest=/tmp mode=0644"
     when: s3_exists|failed
 
   - name: extract
@@ -39,6 +36,15 @@
       - make
       - make install
     when: s3_exists|failed
+
+  - name: create password file
+    sudo: yes
+    file: path=/etc/passwd-s3fs state=touch mode=0400
+
+  - name: "add password"
+    lineinfile: dest=/etc/passwd-s3fs line="{{ item.key }}"
+    sudo: yes
+    with_items: s3fs_mounts
 
   - name: create mount point
     sudo: yes


### PR DESCRIPTION
Very useful role.  Thanks for writing it.

I have updated it so the key is specified on a per bucket basis as I needed to have different access rights for different buckets.

I also added a task to add the mount to /etc/fstab so it persists after reboot.
